### PR TITLE
Removed the column header if the default value was not present. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea
 /node_modules

--- a/index.js
+++ b/index.js
@@ -2,7 +2,10 @@
  * Define custon tags for documenting Vuex state, getters, mutations and actions properties.
  * @module jsdoc-vuex-plugin
  */
-
+/**
+ * @typedef {Object} VuexContext Vuex Context object
+ */
+const logger = require('jsdoc/util/logger');
 const getterTag = require('./lib/getter');
 const mutatorTag = require('./lib/mutator');
 const actionTag = require('./lib/action');
@@ -18,5 +21,9 @@ exports.handlers = {
         getterTag.newDocletHandler(e);
         mutatorTag.newDocletHandler(e);
         actionTag.newDocletHandler(e);
+    },
+    parseBegin(e) {
+        // logger.warn(e)
     }
+
 };

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@
 /**
  * @typedef {Object} VuexContext Vuex Context object
  */
-const logger = require('jsdoc/util/logger');
 const getterTag = require('./lib/getter');
 const mutatorTag = require('./lib/mutator');
 const actionTag = require('./lib/action');
@@ -21,9 +20,5 @@ exports.handlers = {
         getterTag.newDocletHandler(e);
         mutatorTag.newDocletHandler(e);
         actionTag.newDocletHandler(e);
-    },
-    parseBegin(e) {
-        // logger.warn(e)
     }
-
 };

--- a/lib/action.js
+++ b/lib/action.js
@@ -14,7 +14,7 @@ exports.options = {
     onTagged(doclet, tag) { /* eslint-disable-line */
         doclet.action = {
             name: tag.value.name,
-            defaultValue: tag.value.defaultvalue === undefined ? undefined : tag.value.defaultvalue
+            defaultValue: tag.value.defaultvalue
         };
     }
 };

--- a/lib/action.js
+++ b/lib/action.js
@@ -34,7 +34,6 @@ exports.newDocletHandler = function (e) {
   if (value && d.description) {
       d.description = d.description + message
   }
-  // d.memberof = d.memberof.replace('.actions', '')
 
   d.scope = 'action'
   d.kind = 'function'

--- a/lib/action.js
+++ b/lib/action.js
@@ -2,30 +2,41 @@
  * custom jsDoc tag for Vuex actions.
  * @module lib/action
  */
+'use strict'
 
-'use strict';
+const logger = require('jsdoc/util/logger')
 
-exports.name = 'action';
+exports.name = 'action'
 exports.options = {
-    mustHaveValue: false,
-    mustNotHaveDescription: true,
-    canHaveName: true,
-    canHaveType: false,
-    onTagged(doclet, tag) { /* eslint-disable-line */
-        doclet.action = {
-            name: tag.value.name,
-            defaultValue: tag.value.defaultvalue
-        };
+  mustHaveValue: false,
+  mustNotHaveDescription: true,
+  canHaveName: true,
+  canHaveType: false,
+  onTagged (doclet, tag) { /* eslint-disable-line */
+    doclet.action = {
+      name: tag.value.name,
+      defaultValue: tag.value.defaultvalue
     }
-};
+  }
+}
 
-exports.newDocletHandler = function(e) {
-    const action = e.doclet.action;
-    if (action) {
-        e.doclet.scope = 'action';
-        e.doclet.kind = 'function';
-        e.doclet.memberof = e.doclet.memberof.replace('.actions', '');
-        e.doclet.description = `${e.doclet.description}
-                                <br/><i><strong>Vuex Action</strong> => Mutates state property</i><code>${action.defaultValue}</code>`;
-    }
-};
+exports.newDocletHandler = function (e) {
+  const d = e.doclet
+  if (!d.action) {
+    return
+  }
+  const value = d.action.defaultValue
+  let message = ''
+  if (value) {
+      message = `<i><strong>Vuex Action</strong> => Mutates state property</i> <code>${d.action.defaultValue}</code>`
+  }
+
+  if (value && d.description) {
+      d.description = d.description + message
+  }
+  // d.memberof = d.memberof.replace('.actions', '')
+
+  d.scope = 'action'
+  d.kind = 'function'
+
+}

--- a/lib/getter.js
+++ b/lib/getter.js
@@ -21,7 +21,7 @@ exports.options = {
             name: tag.value.name,
             type: tag.value.type ? (tag.value.type.names.length === 1 ? tag.value.type.names[0] : tag.value.type.names) : '',
             description: tag.value.description || '',
-            defaultvalue: tag.value.defaultvalue === undefined ? undefined : tag.value.defaultvalue
+            defaultvalue: tag.value.defaultvalue
         });
     }
 };

--- a/lib/mutator.js
+++ b/lib/mutator.js
@@ -21,7 +21,7 @@ exports.options = {
             name: tag.value.name,
             type: tag.value.type ? (tag.value.type.names.length === 1 ? tag.value.type.names[0] : tag.value.type.names) : '',
             description: tag.value.description || '',
-            defaultvalue: tag.value.defaultvalue === undefined ? undefined : tag.value.defaultvalue
+            defaultvalue: tag.value.defaultvalue
         });
     }
 };

--- a/lib/tabler.js
+++ b/lib/tabler.js
@@ -52,11 +52,11 @@ const buildTableHeader = (columnInfo, title) => { /* eslint-disable-line */
     switch (title) {
     case 'getters':
         typeHeader = 'Returns Type';
-        defaultHeader = '<th>Returns State Property</th>';
+        defaultHeader = columnInfo.showDefaultValue ? '<th>Returns State Property</th>' : '';
         break;
     case 'mutators':
         typeHeader = 'Accepts Type';
-        defaultHeader = '<th>Mutates State Property</th>';
+        defaultHeader = columnInfo.showDefaultValue ? '<th>Mutates State Property</th>' : '';
         break;
     default:
         break;


### PR DESCRIPTION
simplified

```
defaultvalue: tag.value.defaultvalue === undefined ? undefined : tag.value.defaultvalue
```

to

```
defaultvalue: tag.value.defaultvalue
```

Added a check for `columnInfo.showDefaultValue` in tabler.js to prevent an empty description column.